### PR TITLE
Make CLI build on macOS 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
 
 .PHONY: all install install-ci clean dist info test version
 
+OS_UNAME := $(shell uname)
+
+ifeq ($(OS_UNAME), Darwin)
+	LIB_INCLUDE_PATH = -I./native_lib/third-party/apple/Clibsodium.xcframework/macos-arm64_x86_64/Headers/
+	HEADER_INCLUDE_PATH = -L./native_lib/third-party/apple/Clibsodium.xcframework/macos-arm64_x86_64/
+endif
+
 all: dist
 
 install:
+ifneq ($(OS_UNAME), Darwin)
 	sudo apt-get install -qq libsodium-dev
+endif
 
 install-ci:
+ifneq ($(OS_UNAME), Darwin)
 	sudo apt-get update -q
 	sudo apt-get install -qy libsodium-dev
+endif
 
 dist:    install    bin/
 dist-ci: install-ci bin/
@@ -20,16 +31,16 @@ clean:
 
 bin/gen_account_keys: ./cli/gen_account_keys.c
 	mkdir -p ./bin/
-	g++ ./cli/gen_account_keys.c -l sodium -o ./bin/gen_account_keys
+	g++ $(HEADER_INCLUDE_PATH) ./cli/gen_account_keys.c $(LIB_INCLUDE_PATH) -l sodium -o ./bin/gen_account_keys
 	ls -lha ./bin/gen_account_keys
 
 bin/encrypt: ./cli/encrypt.c ./native_lib/*
 	mkdir -p ./bin/
-	g++ ./cli/encrypt.c ./native_lib/DDGSyncCrypto.c -l sodium -o ./bin/encrypt
+	g++ $(HEADER_INCLUDE_PATH) ./cli/encrypt.c ./native_lib/DDGSyncCrypto.c $(LIB_INCLUDE_PATH) -l sodium -o ./bin/encrypt
 
 bin/decrypt: ./cli/decrypt.c ./native_lib/*
 	mkdir -p ./bin/
-	g++ ./cli/decrypt.c ./native_lib/DDGSyncCrypto.c -l sodium -o ./bin/decrypt
+	g++ $(HEADER_INCLUDE_PATH) ./cli/decrypt.c ./native_lib/DDGSyncCrypto.c $(LIB_INCLUDE_PATH) -l sodium -o ./bin/decrypt
 
 test: bin/
 	node --test ./cli/*.test.js

--- a/cli/decrypt.c
+++ b/cli/decrypt.c
@@ -34,7 +34,8 @@ int main(int argc, char **argv) {
 
     // Parse encrypted_msg
     const char *b64_msg = argv[1];
-    unsigned char bin_msg[strlen(b64_msg) * 3 / 4] = {0};
+    unsigned char bin_msg[strlen(b64_msg) * 3 / 4];
+    memset(bin_msg, 0, sizeof(bin_msg));
     const size_t bin_msg_len = from_base64(bin_msg, b64_msg);
     if (bin_msg_len == -1) {
         fprintf(stderr, "Error: failed to decode encrypted_msg! Must be a value base64 string.\n");
@@ -43,7 +44,8 @@ int main(int argc, char **argv) {
 
     // Parse encryption_key
     const char *b64_key = argv[2];
-    unsigned char bin_key[strlen(b64_key) * 3 / 4] = {0};
+    unsigned char bin_key[strlen(b64_key) * 3 / 4];
+    memset(bin_key, 0, sizeof(bin_key));
     const size_t bin_key_len = from_base64(bin_key, b64_key);
     if (bin_key_len == -1) {
         fprintf(stderr, "Error: failed to decode encrypted_key! Must be a value base64 string.\n");
@@ -56,12 +58,14 @@ int main(int argc, char **argv) {
         printf("msg len = %ld (base64) = %ld (bytes)\n", strlen(b64_msg), bin_msg_len);
         printf("key len = %ld (base64) = %ld (bytes)\n", strlen(b64_key), bin_key_len);
         {
-            char printbuf[bin_msg_len * 2] = {0};
+            char printbuf[bin_msg_len * 2];
+            memset(printbuf, 0, sizeof(printbuf));
             to_base64(printbuf, bin_msg, bin_msg_len);
             printf("re-encoded input: '%s'\n", printbuf);
         }
         {
-            char printbuf[bin_key_len * 2] = {0};
+            char printbuf[bin_key_len * 2];
+            memset(printbuf, 0, sizeof(printbuf));
             to_base64(printbuf, bin_key, bin_key_len);
             printf("re-encoded key: '%s'\n", printbuf);
         }
@@ -70,7 +74,8 @@ int main(int argc, char **argv) {
     }
 
     {
-        unsigned char decrypted[bin_msg_len - crypto_secretbox_NONCEBYTES] = {0};
+        unsigned char decrypted[bin_msg_len - crypto_secretbox_NONCEBYTES];
+        memset(decrypted, 0, sizeof(decrypted));
         const int err = ddgSyncDecrypt(decrypted, bin_msg, bin_msg_len, bin_key);
         if (err != 0) {
             fprintf(stderr, "Error: (%d) failed to decrypt message!\n", err);

--- a/cli/encrypt.c
+++ b/cli/encrypt.c
@@ -34,7 +34,8 @@ int main(int argc, char **argv) {
 
     // Parse encryption_key
     const char *b64_key = argv[2];
-    unsigned char bin_key[strlen(b64_key) * 3 / 4] = {0};
+    unsigned char bin_key[strlen(b64_key) * 3 / 4];
+    memset(bin_key, 0, sizeof(bin_key));
     const size_t bin_key_len = from_base64(bin_key, b64_key);
     if (bin_key_len == -1) {
         fprintf(stderr, "Error: failed to decode encrypted_key! Must be a value base64 string.\n");
@@ -46,7 +47,8 @@ int main(int argc, char **argv) {
         printf("---\n");
         printf("key len = %ld (base64) = %ld (bytes)\n", strlen(b64_key), bin_key_len);
         {
-            char printbuf[bin_key_len * 2] = {0};
+            char printbuf[bin_key_len * 2];
+            memset(printbuf, 0, sizeof(printbuf));
             to_base64(printbuf, bin_key, bin_key_len);
             printf("re-encoded key: '%s'\n", printbuf);
         }
@@ -57,14 +59,16 @@ int main(int argc, char **argv) {
         const char *raw_msg = argv[1];
         const size_t raw_msg_len = strlen(raw_msg);
         const size_t encrypted_len = raw_msg_len + crypto_secretbox_MACBYTES + crypto_secretbox_NONCEBYTES;
-        unsigned char encrypted[encrypted_len] = {0};
+        unsigned char encrypted[encrypted_len];
+        memset(encrypted, 0, sizeof(encrypted));
         const int err = ddgSyncEncrypt(encrypted, (unsigned char*)raw_msg, raw_msg_len, bin_key);
         if (err != 0) {
             fprintf(stderr, "Error: (%d) failed to encrypt message!\n", err);
             return 2;
         }
 
-        char b64_encrypted[encrypted_len * 2] = {0};
+        char b64_encrypted[encrypted_len * 2];
+        memset(b64_encrypted, 0, sizeof(b64_encrypted));
         to_base64(b64_encrypted, encrypted, encrypted_len);
         printf("%s\n", b64_encrypted);
     }

--- a/cli/gen_account_keys.c
+++ b/cli/gen_account_keys.c
@@ -111,7 +111,9 @@ int main(int argc, char **argv) {
 
     // Parse secret_key
     const char *b64_secret_key_input = argv[3];
-    unsigned char bin_secret_key[strlen(b64_secret_key_input) * 3 / 4] = {0};
+    unsigned char bin_secret_key[strlen(b64_secret_key_input) * 3 / 4];
+    memset(bin_secret_key, 0, sizeof(bin_secret_key));
+    
     const size_t bin_secret_key_len = from_base64(bin_secret_key, b64_secret_key_input);
     if (bin_secret_key_len == -1) {
         fprintf(stderr, "Error: failed to decode secret_key! Must be a value base64 string.\n");
@@ -134,10 +136,16 @@ int main(int argc, char **argv) {
         return 3;
     }
 
-    char b64_primary_key[sizeof(primary_key) * 2] = {0};
-    char b64_secret_key[bin_secret_key_len * 2] = {0};
-    char b64_protected_secret_key[sizeof(protected_secret_key) * 2] = {0};
-    char b64_hashed_password[sizeof(hashed_password) * 2] = {0};
+    char b64_primary_key[sizeof(primary_key) * 2];
+    char b64_secret_key[bin_secret_key_len * 2];
+    char b64_protected_secret_key[sizeof(protected_secret_key) * 2];
+    char b64_hashed_password[sizeof(hashed_password) * 2];
+    
+    memset(b64_primary_key, 0, sizeof(b64_primary_key));
+    memset(b64_secret_key, 0, sizeof(b64_secret_key));
+    memset(b64_protected_secret_key, 0, sizeof(b64_protected_secret_key));
+    memset(b64_hashed_password, 0, sizeof(b64_hashed_password));
+
     to_base64(b64_primary_key, primary_key, sizeof(primary_key));
     to_base64(b64_secret_key, bin_secret_key, bin_secret_key_len);
     to_base64(b64_protected_secret_key, protected_secret_key, sizeof(protected_secret_key));


### PR DESCRIPTION
This PR fixes the build to make it work on macOS systems: 
- It doesn't install any additional libsodium dev env and rilies on the headers and lib already in this repo. 
- Make CLang compiler shipped with XCode 14 happy.  

You can see a successful run of the Sync login e2e test here: https://github.com/duckduckgo/iOS/pull/2127