### PR TITLE
Output to console if not on CI

### DIFF
--- a/action/github-actions.js
+++ b/action/github-actions.js
@@ -22,14 +22,14 @@ const escapeMessage = (value) => (
 const setOutput = (name, value) => {
   const filePath = process.env.GITHUB_OUTPUT;
   const githubCmd = `${name}=${value}${os.EOL}`;
-  fs.appendFileSync(filePath, githubCmd, { encoding: 'utf8' });
+  process.env.CI ? fs.appendFileSync(filePath, githubCmd, { encoding: 'utf8' }) : console.log(githubCmd);
 }
 
 // Equivalent to `echo "{name}={value}" >> "$GITHUB_STATE"`
 const setState = (name, value) => {
   const filePath = process.env.GITHUB_STATE;
   const githubCmd = `${name}=${value}${os.EOL}`;
-  fs.appendFileSync(filePath, githubCmd, { encoding: 'utf8' });
+  process.env.CI ? fs.appendFileSync(filePath, githubCmd, { encoding: 'utf8' }) : console.log(githubCmd);
 }
 
 const getProps = (message) => {


### PR DESCRIPTION
When running the script locally, it fails because the GITHUB_OUTPUT file is not available. 
This PR makes the script output to the console when not running on CI.
