### PR TITLE
remove the vc++ runtime dependency and compile everything as C

### DIFF
--- a/native_lib/DDGSyncCrypto.c
+++ b/native_lib/DDGSyncCrypto.c
@@ -4,19 +4,18 @@
 #include "DDGSyncCrypto.h"
 #include "sodium.h"
 
-// Seems mad that you still need to define this?!
+#ifndef min
 #define min(x, y) (x < y) ? x : y
+#endif
 
 // Contexts must be 8 characters long but are otherwise arbitrary
 #define DDGSYNC_STRETCHED_PRIMARY_KEY_CONTEXT "Stretchy"
 #define DDGSYNC_PASSWORD_HASH_CONTEXT "Password"
 
-enum DDGSyncCryptoSubkeyIds : int {
-
+typedef enum DDGSyncCryptoSubkeyIds {
     DDGSyncCryptoPasswordHashSubkey = 1,
     DDGSyncCryptoStretchedPrimaryKeySubkey,
-
-};
+} DDGSyncCryptoSubkeyIds;
 
 DDGSyncCryptoResult ddgSyncGenerateAccountKeys(
     unsigned char primaryKey[DDGSYNCCRYPTO_PRIMARY_KEY_SIZE],
@@ -166,7 +165,7 @@ DDGSyncCryptoResult ddgSyncSeal(
     unsigned char *message,
     unsigned long long messageLength) {
 
-    unsigned char* output = (unsigned char*)malloc((crypto_box_SEALBYTES + messageLength) * sizeof(unsigned char));
+    unsigned char* output = (unsigned char*)malloc((crypto_box_SEALBYTES + (size_t)messageLength) * sizeof(unsigned char));
     if (!output) {
         return DDGSYNCCRYPTO_SEAL_FAILED;
     }
@@ -176,7 +175,7 @@ DDGSyncCryptoResult ddgSyncSeal(
         result = DDGSYNCCRYPTO_SEAL_FAILED;
     }
     else {
-        memcpy(sealed, output, crypto_box_SEALBYTES + messageLength);
+        memcpy(sealed, output, crypto_box_SEALBYTES + (size_t)messageLength);
         result = DDGSYNCCRYPTO_OK;
     }
     free(output);
@@ -190,7 +189,7 @@ DDGSyncCryptoResult ddgSyncSealOpen(
     unsigned char secretKey[DDGSYNCCRYPTO_PRIVATE_KEY_SIZE],
     unsigned char *rawBytes) {
 
-    unsigned char* decrypted = (unsigned char*)malloc((cypherTextLength - crypto_box_SEALBYTES) * sizeof(unsigned char));
+    unsigned char* decrypted = (unsigned char*)malloc(((size_t)cypherTextLength - crypto_box_SEALBYTES) * sizeof(unsigned char));
     if (!decrypted) {
         return DDGSYNCCRYPTO_SEAL_FAILED;
     }
@@ -200,7 +199,7 @@ DDGSyncCryptoResult ddgSyncSealOpen(
         result = DDGSYNCCRYPTO_SEAL_FAILED;
     }
     else {
-        memcpy(rawBytes, decrypted, cypherTextLength - crypto_box_SEALBYTES);
+        memcpy(rawBytes, decrypted, (size_t)cypherTextLength - crypto_box_SEALBYTES);
         result = DDGSYNCCRYPTO_OK;
     }
 

--- a/native_lib/DDGSyncCrypto.h
+++ b/native_lib/DDGSyncCrypto.h
@@ -9,7 +9,7 @@
 #ifndef DDGSyncCrypto_h
 #define DDGSyncCrypto_h
 
-typedef enum : int {
+typedef enum DDGSyncCryptoSizes {
     DDGSYNCCRYPTO_HASH_SIZE = 32,
     DDGSYNCCRYPTO_PRIMARY_KEY_SIZE = 32,
     DDGSYNCCRYPTO_SECRET_KEY_SIZE = 32,
@@ -21,7 +21,7 @@ typedef enum : int {
     DDGSYNCCRYPTO_SEAL_EXTRA_BYTES_SIZE = crypto_box_SEALBYTES
 } DDGSyncCryptoSizes;
 
-typedef enum : int {
+typedef enum DDGSyncCryptoResult {
     DDGSYNCCRYPTO_OK,
     DDGSYNCCRYPTO_UNKNOWN_ERROR,
     DDGSYNCCRYPTO_INVALID_USERID,

--- a/windows/WindowsBrowser.Sync.Crypto.Native/Resource.rc
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/Resource.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-FILEVERSION 1,1,0,0
-PRODUCTVERSION 1,1,0,0
+FILEVERSION 1,2,0,0
+PRODUCTVERSION 1,2,0,0
 FILEOS 0x40004
 FILETYPE 0x1
 {
@@ -10,11 +10,11 @@ FILETYPE 0x1
 		{
 			VALUE "CompanyName", "DuckDuckGo"
 				VALUE "FileDescription", "Sync crypto library"
-				VALUE "FileVersion", "1.1.0.0\0"
+				VALUE "FileVersion", "1.2.0.0\0"
 				VALUE "LegalCopyright", "© 2025 DuckDuckGo"
 				VALUE "InternalName", "SyncCrypto.dll"
 				VALUE "ProductName", "SyncCrypto.dll"
-				VALUE "ProductVersion", "1.1.0.0\0"
+				VALUE "ProductVersion", "1.2.0.0\0"
 		}
 	}
 

--- a/windows/WindowsBrowser.Sync.Crypto.Native/Resource.rc
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/Resource.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
-FILEVERSION 1,0,0,0
-PRODUCTVERSION 1,0,0,0
+FILEVERSION 1,1,0,0
+PRODUCTVERSION 1,1,0,0
 FILEOS 0x40004
 FILETYPE 0x1
 {
@@ -10,11 +10,11 @@ FILETYPE 0x1
 		{
 			VALUE "CompanyName", "DuckDuckGo"
 				VALUE "FileDescription", "Sync crypto library"
-				VALUE "FileVersion", "1.0.0.0\0"
-				VALUE "LegalCopyright", "© 2023 DuckDuckGo"
+				VALUE "FileVersion", "1.1.0.0\0"
+				VALUE "LegalCopyright", "© 2025 DuckDuckGo"
 				VALUE "InternalName", "SyncCrypto.dll"
 				VALUE "ProductName", "SyncCrypto.dll"
-				VALUE "ProductVersion", "1.0.0.0\0"
+				VALUE "ProductVersion", "1.1.0.0\0"
 		}
 	}
 

--- a/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
@@ -37,39 +37,39 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>ClangCL</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -125,7 +125,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -135,6 +135,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,7 +153,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -162,6 +163,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -179,7 +181,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -190,6 +192,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -205,7 +208,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -216,6 +219,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -233,7 +237,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -243,6 +247,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -262,7 +267,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;SODIUM_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;WINDOWSBROWSERSYNCCRYPTONATIVE_EXPORTS;_WINDOWS;_USRDLL;SODIUM_STATIC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
@@ -272,6 +277,7 @@
       <CompileAs>CompileAsC</CompileAs>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
@@ -37,39 +37,39 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>ClangCL</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -143,6 +143,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\Win32\Debug\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\Win32\Debug\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmtd.lib,msvcprtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -171,6 +172,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\Win32\Release\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\Win32\Release\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmt.lib,msvcprt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -196,6 +198,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\x64\Debug\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\x64\Debug\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmtd.lib,msvcprtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -221,6 +224,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\arm64\Debug\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\arm64\Debug\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmtd.lib,msvcprtd.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -249,6 +253,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\x64\Release\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\x64\Release\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmt.lib,msvcprt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -277,6 +282,7 @@
       <AdditionalDependencies>..\..\native_lib\third-party\windows\arm64\Release\v143\static\libsodium.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
       <AdditionalLibraryDirectories>..\..\native_lib\third-party\windows\arm64\Release\v143\static\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <IgnoreSpecificDefaultLibraries>libcpmt.lib,msvcprt.lib</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -286,20 +292,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\native_lib\DDGSyncCrypto.c">
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="DDGSyncCryptoSizes.c">
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">CompileAsCpp</CompileAs>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/WindowsBrowser.Sync.Crypto.Native.vcxproj
@@ -132,6 +132,9 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -155,6 +158,9 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -179,6 +185,9 @@
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalUsingDirectories>..\..\native_lib\third-party\windows\include</AdditionalUsingDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -201,6 +210,9 @@
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalUsingDirectories>..\..\native_lib\third-party\windows\include</AdditionalUsingDirectories>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -224,6 +236,9 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -249,6 +264,9 @@
       </PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\..\native_lib\third-party\windows\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <CompileAs>CompileAsC</CompileAs>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ExceptionHandling>false</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/windows/WindowsBrowser.Sync.Crypto.Native/exports.def
+++ b/windows/WindowsBrowser.Sync.Crypto.Native/exports.def
@@ -1,5 +1,3 @@
-LIBRARY SyncCrypto
-
 EXPORTS
     ddgSyncGenerateAccountKeys
     ddgSyncPrepareForLogin


### PR DESCRIPTION
Asana task: https://app.asana.com/0/0/1209236218757490/f
CC: @petevb @AtomicNibble 

Description:

Compiles the native code as C to avoid taking a dependency on the VC runtime library. Added changes to try to prevent re-adding C++ dependencies in the future. Thanks @AtomicNibble for the pointers to:
https://learn.microsoft.com/en-us/cpp/build/reference/nodefaultlib-ignore-libraries?view=msvc-170
https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-170

v1.2.0 is pushed to NuGet which removes the VC++ runtime dependency

```
    <PackageReference Include="WindowsBrowser.Sync.Crypto.Managed.x64" Version="1.2.0" Condition="'$(Platform)' == 'x64'" />
    <PackageReference Include="WindowsBrowser.Sync.Crypto.Managed.x86" Version="1.2.0" Condition="'$(Platform)' == 'x86'" />
    <PackageReference Include="WindowsBrowser.Sync.Crypto.Managed.arm64" Version="1.2.0" Condition="'$(Platform)'=='ARM64'" />
```

Steps to test:
1, build WindowsBrowser.Sync.Crypto / WindowsBrowser.Sync.Crypto.Native
2, in cmd/powershell (Developer Command Prompt for VS has everything) call `dumpbin /dependents full-path-to-WindowsBrowser.Sync.Crypto.Native.dll`
3, Verify that it only depends on KERNEL32.dll and ADVAPI32.dll
4, Verify that config changes are done for all configuration + arch in the vcxproj
