### PR TITLE
Update to central portal and fix 16kb page size linking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,22 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
+
+      - name: Setup Android
+        uses: android-actions/setup-android@v
+
+      - name: Install CMake 3.18.1
+        run: yes | sdkmanager "cmake;3.18.1"
 
       - name: Setup gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Upload Artifacts
         run: cd ./android;./gradlew clean publish --stacktrace
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ARTIFACT_SIGNING_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ARTIFACT_SIGNING_KEY_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ windows/.idea/**
 
 /action/node_modules/
 /cli/node_modules/
+
+#Android
+/.idea/
+android/.idea/
+

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.library' version '7.2.0' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 02 11:36:38 CET 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/sync-crypto/build.gradle
+++ b/android/sync-crypto/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
-    id "com.vanniktech.maven.publish" version "0.23.1"
+    id "com.vanniktech.maven.publish" version "0.33.0"
 }
 
 def getVersionName = { ->
@@ -20,8 +20,8 @@ def buildVersionCode = {
 import com.vanniktech.maven.publish.SonatypeHost
 
 mavenPublishing {
-    // publishing to https://s01.oss.sonatype.org
-    publishToMavenCentral(SonatypeHost.S01, true)
+    // publishing to CentralPortal (https://repo.maven.apache.org/maven2/com/duckduckgo/synccrypto/sync-crypto-android/)
+    publishToMavenCentral()
 
     signAllPublications()
 
@@ -56,6 +56,8 @@ mavenPublishing {
 
 android {
     compileSdk 32
+
+    namespace "com.duckduckgo.synccrypto"
 
     defaultConfig {
         minSdk 23

--- a/android/sync-crypto/src/main/cpp/CMakeLists.txt
+++ b/android/sync-crypto/src/main/cpp/CMakeLists.txt
@@ -27,4 +27,8 @@ target_include_directories(ddgcrypto PRIVATE ${CMAKE_SOURCE_DIR}/../../../../../
 target_link_libraries(ddgcrypto sodium)
 
 # Make sure ddgcrypto is 16KB compatible
-target_link_options(ddgcrypto PRIVATE "-Wl,-z,max-page-size=16384")
+target_link_options(
+  ddgcrypto
+  PRIVATE
+  "-Wl,-z,common-page-size=16384"
+  "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210616215807112?focus=true

## Description
Update to central portal and fix 16kb page size compatibility

## Testing
- [ ] checkout this PR and execute
```bash
./gradlew clean assemble publishToMavenLocal
```
- [ ] Check out https://github.com/duckduckgo/Android/pull/5204 apply the following patch
```diff
Subject: [PATCH] Fix style of data volume
---
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision 444923c21ce09f2e0fca27d5650c0ab32005ba84)
+++ b/build.gradle	(date 1752067989987)
@@ -42,6 +42,7 @@
         google()
         mavenCentral()
         maven { url 'https://jitpack.io' }
+        mavenLocal()
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'
Index: versions.properties
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>ISO-8859-1
===================================================================
diff --git a/versions.properties b/versions.properties
--- a/versions.properties	(revision 444923c21ce09f2e0fca27d5650c0ab32005ba84)
+++ b/versions.properties	(date 1752068035878)
@@ -81,7 +81,7 @@
 
 version.com.duckduckgo.netguard..netguard-android=1.10.2
 
-version.com.duckduckgo.synccrypto..sync-crypto-android=0.4.0
+version.com.duckduckgo.synccrypto..sync-crypto-android=0.5.0-SNAPSHOT
 
 version.com.frybits.harmony..harmony=1.2.6
  
```
- [ ] Build the Android app
```bash
rm -rf build-cache/; ./gradlew clean assembleID
```
- [ ] Install on device and test sync
- [ ] Install on 16kb page size device and test sync
